### PR TITLE
 The structural markup of headings and regions is not optimal or is incorrect. (Issue #239)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "zeta",
     "title": "Zeta",
-    "version": "18.0.2",
+    "version": "18.0.3",
     "private": true,
     "engines": {
         "node": "^18.19.1 || ^20.11.1 || ^22.0.0"

--- a/xc/xc-form/definitions/shared/xc-form-generic-panel/xc-form-generic-panel.component.html
+++ b/xc/xc-form/definitions/shared/xc-form-generic-panel/xc-form-generic-panel.component.html
@@ -6,8 +6,32 @@
 >
     <header>
         <ng-container *ngIf="definition?.label">
-            <h1 *ngIf="!definition?.getParent()" class="items-left items-selectable" tabindex="0">{{definition?.translate(definition?.label) | async}}</h1>
-            <h2 *ngIf="definition?.getParent()" class="items-left items-selectable" tabindex="0">{{definition?.translate(definition?.label) | async}}</h2>
+            <ng-template [ngIf]="!!definition.headersize" [ngIfElse]="elseBlock1">
+                @switch (definition.headersize) {
+                    @case (1) {
+                         <h1 class="items-left items-selectable" tabindex="0">{{definition?.translate(definition?.label) | async}}</h1>
+                    }
+                    @case (2) {
+                         <h2 class="items-left items-selectable" tabindex="0">{{definition?.translate(definition?.label) | async}}</h2>
+                    }
+                    @case (3) {
+                         <h3 class="items-left items-selectable" tabindex="0">{{definition?.translate(definition?.label) | async}}</h3>
+                    }
+                    @case (4) {
+                         <h4 class="items-left items-selectable" tabindex="0">{{definition?.translate(definition?.label) | async}}</h4>
+                    }
+                    @case (5) {
+                         <h5 class="items-left items-selectable" tabindex="0">{{definition?.translate(definition?.label) | async}}</h5>
+                    }
+                    @case (6) {
+                         <h6 class="items-left items-selectable" tabindex="0">{{definition?.translate(definition?.label) | async}}</h6>
+                    }
+                }
+            </ng-template>
+            <ng-template #elseBlock1>
+                <h1 *ngIf="!definition?.getParent()" class="items-left items-selectable" tabindex="0">{{definition?.translate(definition?.label) | async}}</h1>
+                <h2 *ngIf="definition?.getParent()" class="items-left items-selectable" tabindex="0">{{definition?.translate(definition?.label) | async}}</h2>
+            </ng-template>
         </ng-container>
         <div class="items-left">
             <xc-definition-proxy *ngFor="let child of definition?.header?.leftArea?.children"

--- a/xc/xc-form/definitions/xo/containers.model.ts
+++ b/xc/xc-form/definitions/xo/containers.model.ts
@@ -223,6 +223,8 @@ export class XoFormPanelDefinition extends XoFormDefinition {
     @XoProperty(XoPanelBoxDefinition)
     footer: XoPanelBoxDefinition;
 
+    @XoProperty()
+    headersize;
 
     protected afterDecode() {
         super.afterDecode();


### PR DESCRIPTION
The structural markup of headings and regions is not optimal or is incorrect.
(Story DHICB-11124) Torben Siegismund is involved.

Must be implemented together with the issue
"The structural markup of headings and regions is not optimal or is incorrect. #1416"
 in the xyna-factory.