### PR TITLE
Removed obsolete translations for xc-form

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 
   "name": "zeta",
   "title": "Zeta",
-  "version": "19.0.24",
+  "version": "19.0.25",
   "private": true,
   "type": "module",
   "engines": {

--- a/xc/xc-form/locale/xc-translations.de-DE.ts
+++ b/xc/xc-form/locale/xc-translations.de-DE.ts
@@ -50,11 +50,6 @@ export const xcFormTranslations_deDE: I18nTranslation[] = [
     { key: 'zeta.xc-form-base.ip', value: 'WERT IST KEINE IP-ADRESSE' },
     { key: 'zeta.xc-form-base.message', value: 'KEINE NACHRICHT DEFINIERT' },
 
-    // Panel
-    { key: 'Close', value: 'Schließen' },
-    { key: 'Maximize', value: 'Maximieren' },
-    { key: 'Standard', value: 'Zurück auf Standardgröße' },
-
     // Workflow defined UI Dialog
     { key: 'definedUi.dialog.close', value: 'Schließen' }
 ];


### PR DESCRIPTION
Removed obsolete translation tuples for 'Close', 'Maximize' and 'Standard'. These existed only in the German version of this translation context.