### PR TITLE
Using $xc-checkbox-height to determine width and height of checkbox elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 
   "name": "zeta",
   "title": "Zeta",
-  "version": "19.0.33",
+  "version": "19.0.34",
   "private": true,
   "type": "module",
   "engines": {

--- a/xc/xc-checkbox/xc-checkbox.component.scss
+++ b/xc/xc-checkbox/xc-checkbox.component.scss
@@ -58,8 +58,8 @@
 
                  .mat-mdc-checkbox-touch-target,
                  input {
-                     height: 16px;
-                     width: 16px;
+                     height: $xc-checkbox-height;
+                     width: $xc-checkbox-height;
                      top: 50%;
                      left: 50%;
                      transform: translate(-50%, -50%);
@@ -76,8 +76,8 @@
          .mat-mdc-checkbox .mdc-checkbox__ripple {
              left: calc(50% - 14px);
              top: calc(50% - 14px);
-             height: 28px;
-             width: 28px;
+             height: calc($xc-checkbox-height - 4px);;
+             width: calc($xc-checkbox-height - 4px);;
          }
 
          .mdc-checkbox:hover .mdc-checkbox__ripple,


### PR DESCRIPTION
Using $xc-checkbox-height to determine width and height of .mat-mdc-checkbox-touch-target, .mat-mdc-checkbox and .mdc-checkbox__ripple.