### PR TITLE
Added trimming of key and translation to the i18n.service

### DIFF
--- a/i18n/i18n.directive.ts
+++ b/i18n/i18n.directive.ts
@@ -108,7 +108,7 @@ export class XcI18nTranslateDirective extends XcI18nBase implements OnInit, OnDe
 
         const isXc = this.element.tagName.startsWith('XC-');
 
-        const cont = trim(this.element.textContent);
+        const cont = this.element.textContent?.trim();
 
         if (cont && !isXc) {
             this.subs.push(this.localService.languageChange.subscribe(() => {
@@ -116,7 +116,7 @@ export class XcI18nTranslateDirective extends XcI18nBase implements OnInit, OnDe
                     this.content.key = cont;
                 }
                 const translation = this.i18n.getTranslation(this._context ? this._context + '.' + this.content.key : this.content.key);
-                this.element.textContent = trim(translation?.value);
+                this.element.textContent = translation?.value;
 
                 if (translation?.pronunciationLanguage) {
                     this.element.setAttribute('lang', translation.pronunciationLanguage);

--- a/i18n/i18n.service.ts
+++ b/i18n/i18n.service.ts
@@ -192,6 +192,7 @@ export class I18nService {
                 const type = typeparts.length >= 2 ? typeparts[0] : '';
                 const path = typeparts.length >= 2 ? typeparts.slice(1).join(':') : typeparts[0];
                 const parts: string[] = path.split('.');
+                parts[parts.length - 1] = parts[parts.length -1].trim(); // trim key before translating
                 let withType = !!type;
                 let looping = true;
                 while (!translation && looping) {
@@ -209,7 +210,11 @@ export class I18nService {
                     }
                 }
             } else {
-                translation = translationMap.get(key);
+                translation = translationMap.get(key.trim());
+            }
+
+            if (translation?.value) {
+                translation.value = translation.value.trim();
             }
 
             // only cache it if a valid value for given key was found

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zeta",
   "title": "Zeta",
-  "version": "20.0.7",
+  "version": "20.0.8",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
In **i18n.service.ts**:
During processing of the key to be translated, optional context is added before the String is given to the retrieveTranlation method.
- In the case that there was a context prefix added, we need to trim the last part of the parts array. 
- Else, we can just trim the key.

After a translation was fetched from the translationMap, we also trim the return value.

In **i18n.directive.ts**:
Replaced the zeta.base.trim() method with the String trim(). String trim() removes all leading and trailing whitespace characters, zeta.base.trim() does not remove all unicode whitespaces.
- Maybe the trim method should be renamed in zeta.base?
- Is this specific RegEx replacement needed?

The trim is kept in line 111, because there is a comparison done before getTranslation is called. 
The trim of the output is removed, because i18n.service.ts now already trims the result.