### PR TITLE
Added an explicit aria-sort attribute to a table header element of xc-table for better screen reader support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zeta",
   "title": "Zeta",
-  "version": "21.0.14",
+  "version": "21.0.15",
   "private": true,
   "type": "module",
   "engines": {

--- a/xc/shared/xc-sort.ts
+++ b/xc/shared/xc-sort.ts
@@ -65,3 +65,14 @@ export function XcSortPredicate<T>(sortDirection: XcSortDirection, accessor: (t:
             : (vala < valb ? -1 : 1) * direction;
     };
 }
+
+export function XcSortDirectionToLabel(dir: XcSortDirection): string {
+    switch (dir) {
+        case XcSortDirection.asc:
+            return 'ascending';
+        case XcSortDirection.dsc:
+            return 'descending';
+        default:
+            return 'none';
+    }
+}

--- a/xc/xc-table/xc-table.component.html
+++ b/xc/xc-table/xc-table.component.html
@@ -42,7 +42,7 @@
   <!-- Container template view of a table body row -->
   @for (column of columns; let i = $index; track i) {
     <ng-container [matColumnDef]="getColumnID(column)">
-      <th mat-header-cell *matHeaderCellDef attr.aria-label="{{i18n.translate(column.name)}}" scope="col">
+      <th mat-header-cell *matHeaderCellDef attr.aria-sort="{{getAriaSortForColumn(column)}}" attr.aria-label="{{i18n.translate(column.name)}}" scope="col">
         <span mat-sort-header [disabled]="column.disableSort">{{i18n.translate(column.name) || '&nbsp;'}}</span>
         <div class="filter-container">
           @if (allowFilter) {

--- a/xc/xc-table/xc-table.component.html
+++ b/xc/xc-table/xc-table.component.html
@@ -42,7 +42,7 @@
   <!-- Container template view of a table body row -->
   @for (column of columns; let i = $index; track i) {
     <ng-container [matColumnDef]="getColumnID(column)">
-      <th mat-header-cell *matHeaderCellDef attr.aria-label="{{translateLabels ? i18n.translate(column.name) : column.name}}" scope="col">
+      <th mat-header-cell *matHeaderCellDef attr.aria-sort="{{getAriaSortForColumn(column)}}" attr.aria-label="{{translateLabels ? i18n.translate(column.name) : column.name}}" scope="col">
         <span mat-sort-header [disabled]="column.disableSort">{{ translateLabels ? i18n.translate(column.name) : column.name || '&nbsp;'}}</span>
         <div class="filter-container">
           @if (allowFilter) {

--- a/xc/xc-table/xc-table.component.ts
+++ b/xc/xc-table/xc-table.component.ts
@@ -28,7 +28,7 @@ import { coerceBoolean } from '../../base';
 import { I18nService, LocaleService } from '../../i18n';
 import { XcIdentityDataWrapper } from '../shared/xc-data-wrapper';
 import { XcOptionItemString } from '../shared/xc-item';
-import { XcSortDirection, XcSortDirectionFromString } from '../shared/xc-sort';
+import { XcSortDirection, XcSortDirectionFromString, XcSortDirectionToLabel } from '../shared/xc-sort';
 import { XcVarDirective } from '../shared/xc-var.directive';
 import { XcIconButtonComponent } from '../xc-button/xc-icon-button.component';
 import { XcAutocompleteDataWrapper, XcFormAutocompleteComponent } from '../xc-form/xc-form-autocomplete/xc-form-autocomplete.component';
@@ -348,6 +348,15 @@ export class XcTableComponent implements AfterViewInit, OnDestroy {
 
     getColumnID(column: XcTableColumn): string {
         return [column.path, column.name, column.disableSort ?? false, column.disableFilter ?? false, column.filterTooltip ?? '', column.filterMultiselect ?? false].join('\0');
+    }
+
+
+    getAriaSortForColumn(column: XcTableColumn): string {
+        if(this.dataSource.getSortPath() ===  column.path) {
+            const sortDirection = this.dataSource.getSortDirection();
+            return XcSortDirectionToLabel(sortDirection);
+        }
+        return null;
     }
 
 

--- a/xc/xc-table/xc-table.component.ts
+++ b/xc/xc-table/xc-table.component.ts
@@ -28,7 +28,7 @@ import { coerceBoolean } from '../../base';
 import { I18nService, LocaleService } from '../../i18n';
 import { XcIdentityDataWrapper } from '../shared/xc-data-wrapper';
 import { XcOptionItemString } from '../shared/xc-item';
-import { XcSortDirection, XcSortDirectionFromString } from '../shared/xc-sort';
+import { XcSortDirection, XcSortDirectionFromString, XcSortDirectionToLabel } from '../shared/xc-sort';
 import { XcVarDirective } from '../shared/xc-var.directive';
 import { XcIconButtonComponent } from '../xc-button/xc-icon-button.component';
 import { XcAutocompleteDataWrapper, XcFormAutocompleteComponent } from '../xc-form/xc-form-autocomplete/xc-form-autocomplete.component';
@@ -357,6 +357,15 @@ export class XcTableComponent implements AfterViewInit, OnDestroy {
 
     getColumnID(column: XcTableColumn): string {
         return [column.path, column.name, column.disableSort ?? false, column.disableFilter ?? false, column.filterTooltip ?? '', column.filterMultiselect ?? false].join('\0');
+    }
+
+
+    getAriaSortForColumn(column: XcTableColumn): string {
+        if(this.dataSource.getSortPath() ===  column.path) {
+            const sortDirection = this.dataSource.getSortDirection();
+            return XcSortDirectionToLabel(sortDirection);
+        }
+        return null;
     }
 
 


### PR DESCRIPTION
The aria-sort attribute is only shown in the table header, if the current column is sorted. Added an exported function to xc-sort to fetch the full sort direction label.