### PR TITLE
Screenreader - Fix Validators Error Announcement

### DIFF
--- a/xc/xc-form/xc-form-autocomplete/xc-form-autocomplete.component.html
+++ b/xc/xc-form/xc-form-autocomplete/xc-form-autocomplete.component.html
@@ -54,6 +54,7 @@
       [type]="type"
       [placeholder]="placeholder"
       [formControl]="formControl"
+      [errorStateMatcher]="errorStateMatcher"
       [matAutocomplete]="auto"
       (mousedown)="mousedown($event)"
       (focus)="onfocus($event)"
@@ -90,7 +91,7 @@
   }
 
   @if (errorVisible) {
-    <mat-error align="end">{{errorContent}}</mat-error>
+    <mat-error align="end" aria-live="off">{{errorContent}}</mat-error>
   }
 
   @if (suffixVisible && !readonly) {

--- a/xc/xc-form/xc-form-base/xc-form-base.component.ts
+++ b/xc/xc-form/xc-form-base/xc-form-base.component.ts
@@ -16,7 +16,8 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  */
 import { AfterContentInit, Component, ElementRef, EventEmitter, HostBinding, inject, Input, OnDestroy, Output } from '@angular/core';
-import { FormControl, ValidatorFn, Validators } from '@angular/forms';
+import { FormControl, FormGroupDirective, NgForm, ValidatorFn, Validators } from '@angular/forms';
+import { ErrorStateMatcher } from '@angular/material/core';
 
 import { Subscription } from 'rxjs';
 
@@ -31,6 +32,19 @@ export enum FloatStyle {
     never = 'never',
     auto = 'auto',
     always = 'always'
+}
+
+class XcFormErrorStateMatcher implements ErrorStateMatcher {
+
+    constructor(private readonly component: XcFormBaseComponent) {
+    }
+
+    isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
+        if (!control || this.component.readonly) {
+            return false;
+        }
+        return control.invalid && (control.dirty || control.touched || !!form?.submitted);
+    }
 }
 
 
@@ -150,6 +164,7 @@ export class XcFormBaseComponent extends XcFormComponent implements AfterContent
     protected _placeholder: KeyTranslationPair = { key: '', translated: '' };
 
     readonly formControl = new FormControl();
+    readonly errorStateMatcher: ErrorStateMatcher = new XcFormErrorStateMatcher(this);
 
     @Output()
     readonly valueChange = this.formControl.valueChanges;
@@ -245,7 +260,7 @@ export class XcFormBaseComponent extends XcFormComponent implements AfterContent
 
 
     get errorVisible(): boolean {
-        return this.formControl.errors !== null && this.formControl.touched && !this.readonly;
+        return this.errorStateMatcher.isErrorState(this.formControl, null);
     }
 
 

--- a/xc/xc-form/xc-form-input/xc-form-input.component.html
+++ b/xc/xc-form/xc-form-input/xc-form-input.component.html
@@ -2,12 +2,13 @@
   <mat-label>{{label}}</mat-label>
 
   <input matInput autocomplete="off" [type]="type" [placeholder]="placeholder" [formControl]="formControl"
+    [errorStateMatcher]="errorStateMatcher"
     (focus)="focus.emit($event)" (blur)="blur.emit($event)" (keydown)="onkeydown($event)"
     [tabIndex]="disabled ? -1 : tabIndex" [attr.aria-label]="ariaLabel" [readonly]="readonly"
     [required]="required">
 
   @if (errorVisible) {
-  <mat-error align="end">{{errorContent}}</mat-error>
+  <mat-error align="end" aria-live="off">{{errorContent}}</mat-error>
   }
 
 

--- a/xc/xc-form/xc-form-textarea/xc-form-textarea.component.html
+++ b/xc/xc-form/xc-form-textarea/xc-form-textarea.component.html
@@ -5,6 +5,7 @@
       class="zeta-scrollbar"
       matInput
       autocomplete="off"
+      [errorStateMatcher]="errorStateMatcher"
       [placeholder]="placeholder"
       [formControl]="formControl"
       [cdkAutosizeMinRows]="minLines"
@@ -18,6 +19,6 @@
     ></textarea>
   </div>
   @if (errorVisible) {
-    <mat-error align="end">{{errorContent}}</mat-error>
+    <mat-error align="end" aria-live="off">{{errorContent}}</mat-error>
   }
 </mat-form-field>


### PR DESCRIPTION
_Screenreader_ - Fix Validators Error Text is only read after leaving an Input Field

Validators Error Text (red below input fields) is only read, after the Input field is exited. At least for mandatory fields.