### PR TITLE
fix: improve keyboard focus handling for menu

### DIFF
--- a/xc/xc-master-detail/xc-master-detail-focuscandidate.directive.ts
+++ b/xc/xc-master-detail/xc-master-detail-focuscandidate.directive.ts
@@ -68,7 +68,7 @@ export class XcMasterDetailFocusCandidateDirective implements OnInit {
                 if (element.focus) {
                     const tabIndexBackup = element.tabIndex;
                     element.tabIndex = 0;
-                    element.focus();
+                    element.focus({ preventScroll: true });
                     element.tabIndex = tabIndexBackup;
 
                     if (this.observer && this.observer.afterFocus) {

--- a/xc/xc-table/xc-table.component.ts
+++ b/xc/xc-table/xc-table.component.ts
@@ -93,6 +93,7 @@ export class XcTableComponent implements AfterViewInit, OnDestroy {
             if (!this.lazyUpdate) {
                 this.dataSource.refresh();
             }
+            this.updateHeaderScrollOffset();
         });
 
         // make table body focusable and set key listener
@@ -107,6 +108,8 @@ export class XcTableComponent implements AfterViewInit, OnDestroy {
 
         this.focusViaTabDetectionSubscription = this._a11y.emitElementFocusStateChange(this.tbody).subscribe(state => {
             if (state.type === 'focus' && state.achieved === 'keyboard') {
+                this.updateHeaderScrollOffset();
+
                 let row = this.getFocusedRow();
                 let rowEl = this.getFocusedRowElement();
                 const rowFound = row && rowEl;
@@ -587,13 +590,30 @@ export class XcTableComponent implements AfterViewInit, OnDestroy {
     }
 
 
+    private updateHeaderScrollOffset() {
+        if (!this.thead || !this.tbody) {
+            return;
+        }
+        const headerHeight = this.thead.getBoundingClientRect().height;
+        const host: HTMLElement = this.elementRef.nativeElement;
+        host.style.scrollPaddingTop = headerHeight + 'px';
+        this.tbody.style.scrollMarginTop = headerHeight + 'px';
+    }
+
+
     focusRowElement(element: HTMLTableRowElement) {
+        if (!element || !this.thead) {
+            return;
+        }
         const parent = this.elementRef.nativeElement;
-        const topOffset = this.thead.getBoundingClientRect().height;
         const e = element.getBoundingClientRect();
         const p = parent.getBoundingClientRect();
-        if (e.top < p.top + topOffset) {
-            parent.scrollTop -= p.top - e.top + topOffset + 1;
+        const headerBottom = this.thead.getBoundingClientRect().bottom;
+        if (e.top >= headerBottom && e.bottom <= p.bottom) {
+            return;
+        }
+        if (e.top < headerBottom) {
+            parent.scrollTop -= headerBottom - e.top + 1;
         }
         if (e.bottom > p.bottom) {
             parent.scrollTop += e.bottom - p.bottom + 1;


### PR DESCRIPTION
## Summary

This PR fixes an issue where `xc-table` scrolls down slightly when keyboard focus moves into the table.

The issue can be seen in two cases:

1. When the user presses `Tab` from the last filter field into the table.
2. When the user closes the details panel and focus returns to the table.

---

## Current Behavior

### Tab from filters into the table

When the user tabs from the last filter field into the table body, the table scrolls down slightly even though the first row is already visible.

### Close Details

When the user closes the details panel using the keyboard, focus returns to the table, but the table also scrolls down slightly.

This creates an unnecessary jump in the UI.

---

## Expected Behavior

* Moving focus from the last filter field into the table should not change the scroll position if the first row is already visible.
* Closing the details panel should return focus to the table without moving the scroll position.
* Using `ArrowUp` and `ArrowDown` should still scroll the table when the focused row is outside the visible area.

---

## Root Cause

The table body (`tbody`) is focusable.

When focus moves to it, the browser automatically tries to scroll it into view. Since the table body is larger than the visible table area, this can cause an unnecessary scroll jump.

The same issue happens when focus is restored programmatically after closing the details panel.

The row visibility check also used the table header height instead of the actual visible bottom position of the sticky header.

---

## Changes Made

### `xc-table`

* Added a scroll offset for the sticky header and filter row.
* Updated the row visibility check to use the actual bottom position of the table header.
* Prevented unnecessary scrolling when the focused row is already visible.

### `xc-master-detail-focuscandidate`

* Updated focus restoration to use:

```ts
element.focus({ preventScroll: true });
```

This returns focus to the table without forcing the browser to scroll.

---

## Files Changed

* `xc/xc-table/xc-table.component.ts`
* `xc/xc-master-detail/xc-master-detail-focuscandidate.directive.ts`

---

## Scope

* The fix is limited to the shared Zeta table and master-detail focus logic.
* No application-specific workaround was added.
