### PR TITLE
fix: improve keyboard focus handling for menu

### DIFF
--- a/xc/xc-master-detail/xc-master-detail-focuscandidate.directive.ts
+++ b/xc/xc-master-detail/xc-master-detail-focuscandidate.directive.ts
@@ -68,7 +68,7 @@ export class XcMasterDetailFocusCandidateDirective implements OnInit {
                 if (element.focus) {
                     const tabIndexBackup = element.tabIndex;
                     element.tabIndex = 0;
-                    element.focus();
+                    element.focus({ preventScroll: true });
                     element.tabIndex = tabIndexBackup;
 
                     if (this.observer && this.observer.afterFocus) {

--- a/xc/xc-table/xc-table.component.ts
+++ b/xc/xc-table/xc-table.component.ts
@@ -514,33 +514,27 @@ export class XcTableComponent implements AfterViewInit, OnDestroy {
 
     getPrevRow(row: any): any {
         if (this.dataSource) {
-            let idx = this.getRowIndex(row) - 1;
-            if (idx < 0) {
-                idx += this.dataSource.rows.length;
-            }
-            return this.dataSource.rows[idx];
+            const idx = this.getRowIndex(row) - 1;
+            return idx >= 0 ? this.dataSource.rows[idx] : row;
         }
     }
 
 
     getPrevRowElement(row: HTMLTableRowElement): HTMLTableRowElement {
-        return row ? (row.previousElementSibling || row.parentElement.children[row.parentElement.children.length - 1]) as HTMLTableRowElement : null;
+        return row ? (row.previousElementSibling as HTMLTableRowElement) || row : null;
     }
 
 
     getNextRow(row: any): any {
         if (this.dataSource) {
-            let idx = this.getRowIndex(row) + 1;
-            if (idx > this.dataSource.rows.length - 1) {
-                idx -= this.dataSource.rows.length;
-            }
-            return this.dataSource.rows[idx];
+            const idx = this.getRowIndex(row) + 1;
+            return idx < this.dataSource.rows.length ? this.dataSource.rows[idx] : row;
         }
     }
 
 
     getNextRowElement(row: HTMLTableRowElement): HTMLTableRowElement {
-        return row ? (row.nextElementSibling || row.parentElement.children[0]) as HTMLTableRowElement : null;
+        return row ? (row.nextElementSibling as HTMLTableRowElement) || row : null;
     }
 
 
@@ -588,6 +582,9 @@ export class XcTableComponent implements AfterViewInit, OnDestroy {
 
 
     focusRowElement(element: HTMLTableRowElement) {
+        if (!element || !this.thead) {
+            return;
+        }
         const parent = this.elementRef.nativeElement;
         const topOffset = this.thead.getBoundingClientRect().height;
         const e = element.getBoundingClientRect();

--- a/xc/xc-table/xc-table.component.ts
+++ b/xc/xc-table/xc-table.component.ts
@@ -514,27 +514,33 @@ export class XcTableComponent implements AfterViewInit, OnDestroy {
 
     getPrevRow(row: any): any {
         if (this.dataSource) {
-            const idx = this.getRowIndex(row) - 1;
-            return idx >= 0 ? this.dataSource.rows[idx] : row;
+            let idx = this.getRowIndex(row) - 1;
+            if (idx < 0) {
+                idx += this.dataSource.rows.length;
+            }
+            return this.dataSource.rows[idx];
         }
     }
 
 
     getPrevRowElement(row: HTMLTableRowElement): HTMLTableRowElement {
-        return row ? (row.previousElementSibling as HTMLTableRowElement) || row : null;
+        return row ? (row.previousElementSibling || row.parentElement.children[row.parentElement.children.length - 1]) as HTMLTableRowElement : null;
     }
 
 
     getNextRow(row: any): any {
         if (this.dataSource) {
-            const idx = this.getRowIndex(row) + 1;
-            return idx < this.dataSource.rows.length ? this.dataSource.rows[idx] : row;
+            let idx = this.getRowIndex(row) + 1;
+            if (idx > this.dataSource.rows.length - 1) {
+                idx -= this.dataSource.rows.length;
+            }
+            return this.dataSource.rows[idx];
         }
     }
 
 
     getNextRowElement(row: HTMLTableRowElement): HTMLTableRowElement {
-        return row ? (row.nextElementSibling as HTMLTableRowElement) || row : null;
+        return row ? (row.nextElementSibling || row.parentElement.children[0]) as HTMLTableRowElement : null;
     }
 
 
@@ -582,9 +588,6 @@ export class XcTableComponent implements AfterViewInit, OnDestroy {
 
 
     focusRowElement(element: HTMLTableRowElement) {
-        if (!element || !this.thead) {
-            return;
-        }
         const parent = this.elementRef.nativeElement;
         const topOffset = this.thead.getBoundingClientRect().height;
         const e = element.getBoundingClientRect();


### PR DESCRIPTION
## Summary

This PR fixes an issue where `xc-table` scrolls down slightly when keyboard focus moves into the table.

The issue can be seen in two cases:

1. When the user presses `Tab` from the last filter field into the table.
2. When the user closes the details panel and focus returns to the table.

---

## Current Behavior

### Tab from filters into the table

When the user tabs from the last filter field into the table body, the table scrolls down slightly even though the first row is already visible.

### Close Details

When the user closes the details panel using the keyboard, focus returns to the table, but the table also scrolls down slightly.

This creates an unnecessary jump in the UI.

---

## Expected Behavior

* Moving focus from the last filter field into the table should not change the scroll position if the first row is already visible.
* Closing the details panel should return focus to the table without moving the scroll position.
* Using `ArrowUp` and `ArrowDown` should still scroll the table when the focused row is outside the visible area.

---

## Root Cause

The table body (`tbody`) is focusable.

When focus moves to it, the browser automatically tries to scroll it into view. Since the table body is larger than the visible table area, this can cause an unnecessary scroll jump.

The same issue happens when focus is restored programmatically after closing the details panel.

The row visibility check also used the table header height instead of the actual visible bottom position of the sticky header.

---

## Changes Made

### `xc-master-detail-focuscandidate`

* Updated focus restoration to use:

```ts
element.focus({ preventScroll: true });
```

This returns focus to the table without forcing the browser to scroll.

---

## Files Changed

* `xc/xc-master-detail/xc-master-detail-focuscandidate.directive.ts`

---

## Scope

* The fix is limited to the shared Zeta table and master-detail focus logic.
* No application-specific workaround was added.
