### PR TITLE
add role list dropdown to smartcard login

### DIFF
--- a/auth/auth.service.ts
+++ b/auth/auth.service.ts
@@ -20,7 +20,7 @@ import { inject, Injectable } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { Observable, of } from 'rxjs';
-import { catchError, filter, mapTo, switchMap, tap } from 'rxjs/operators';
+import { catchError, filter, map, mapTo, switchMap, tap } from 'rxjs/operators';
 
 import { A11yService } from '../a11y';
 import { ApiService, RuntimeContext, XoConsistencyCheck, XoObject } from '../api';
@@ -37,7 +37,21 @@ export interface SmartCardInfo {
     username: string;
     externaldomains: string[]; // TODO: rename to "externalDomains"
     userdisplayname: string;   // TODO: rename to "userDisplayname"
-    availableRoles?: string[];
+    domains?: SmartCardDomainInfo[];
+}
+
+
+export interface SmartCardDomainInfo {
+    name: string;
+    roles: string[];
+}
+
+
+interface SmartCardInfoResponse {
+    username?: string;
+    externaldomains?: string[];
+    userdisplayname?: string;
+    domains?: SmartCardDomainInfo[];
 }
 
 
@@ -233,7 +247,31 @@ export class AuthService {
 
     fetchSmartCardInfo(): Observable<SmartCardInfo> {
         // TODO: url should be 'auth/externalinfo'
-        return this.http.get<SmartCardInfo>('auth/externalUserLoginInformation');
+        return this.http.get<SmartCardInfoResponse>('auth/externalUserLoginInformation').pipe(
+            map(info => this.normalizeSmartCardInfo(info))
+        );
+    }
+
+    /**
+     * normalizes backend smart card info into a clean, UI-friendly model with robust data.
+     */
+    private normalizeSmartCardInfo(info: SmartCardInfoResponse): SmartCardInfo {
+        const domains = (info.domains ?? [])
+            .filter(domain => !!domain?.name)
+            .map(domain => ({
+                name: domain.name,
+                roles: (domain.roles ?? []).filter(role => !!role)
+            }));
+
+        const externaldomains = (info.externaldomains ?? [])
+            .filter(domain => !!domain);
+
+        return {
+            username: info.username ?? '',
+            userdisplayname: info.userdisplayname ?? '',
+            externaldomains,
+            domains
+        };
     }
 
 

--- a/auth/auth.service.ts
+++ b/auth/auth.service.ts
@@ -37,6 +37,7 @@ export interface SmartCardInfo {
     username: string;
     externaldomains: string[]; // TODO: rename to "externalDomains"
     userdisplayname: string;   // TODO: rename to "userDisplayname"
+    availableRoles?: string[];
 }
 
 
@@ -256,9 +257,9 @@ export class AuthService {
      * @param domain Domain
      * @param force Enforce login
      */
-    smartCardLogin(domain: string, force = false): Observable<SessionInfo> {
+    smartCardLogin(domain: string, force = false, selectedRole?: string): Observable<SessionInfo> {
         // TODO: url should be 'auth/externallogin'
-        return this.customLogin('auth/externalUserLogin', XoExternalUserLoginRequest.withDomain(domain, force));
+        return this.customLogin('auth/externalUserLogin', XoExternalUserLoginRequest.withDomain(domain, force, selectedRole));
     }
 
 

--- a/auth/forms/smart-card-login-tab.component.ts
+++ b/auth/forms/smart-card-login-tab.component.ts
@@ -20,6 +20,7 @@ import { Component, Injector, inject } from '@angular/core';
 import { XcTabComponent } from '../../xc';
 import { LoginComponentData } from '../login/auth-login.component';
 import { XcFormInputComponent } from '../../xc/xc-form/xc-form-input/xc-form-input.component';
+import { XcFormAutocompleteComponent } from '../../xc/xc-form/xc-form-autocomplete/xc-form-autocomplete.component';
 import { XcI18nTranslateDirective } from '../../i18n/i18n.directive';
 
 
@@ -27,7 +28,7 @@ import { XcI18nTranslateDirective } from '../../i18n/i18n.directive';
     selector: 'smart-card-login-tab',
     templateUrl: './smart-card-login.component.html',
     styleUrls: ['./smart-card-login.component.scss'],
-    imports: [XcFormInputComponent, XcI18nTranslateDirective]
+    imports: [XcFormInputComponent, XcFormAutocompleteComponent, XcI18nTranslateDirective]
 })
 export class SmartCardLoginTabComponent extends XcTabComponent<void, LoginComponentData> {
 

--- a/auth/forms/smart-card-login.component.html
+++ b/auth/forms/smart-card-login.component.html
@@ -7,12 +7,12 @@
                [xc-form-field-tab-index-suffix]="data.usernameSuffixTabIndex"
 />
 
-@if (data.roleSelectionDataWrapper && (data.availableRoles || []).length > 0) {
+@if (data.roleSelectionDataWrapper && (data.roleSelectionDataWrapper.values || []).length > 0) {
  <xc-form-autocomplete xc-i18n
                        label="role-input"
                        [(xc-form-autocomplete-option)]="data.roleSelectionDataWrapper.value"
                        [xc-form-autocomplete-options]="data.roleSelectionDataWrapper.values"
-                       [readonly]="data.disabled || (data.availableRoles || []).length <= 1"
+                       [readonly]="data.disabled || (data.roleSelectionDataWrapper.values || []).length <= 1"
                        xc-form-autocomplete-asdropdown
                        [xc-form-field-tab-index]="data.roleTabIndex"
                        [xc-form-field-tab-index-suffix]="data.roleSuffixTabIndex"

--- a/auth/forms/smart-card-login.component.html
+++ b/auth/forms/smart-card-login.component.html
@@ -1,8 +1,21 @@
 <xc-form-input xc-i18n
-    label="user-input"
-    [(value)]="data.username"
-    name="smartCardUser"
-    readonly
-    [xc-form-field-tab-index]="data.usernameTabIndex"
-    [xc-form-field-tab-index-suffix]="data.usernameSuffixTabIndex"
+               label="user-input"
+               [(value)]="data.username"
+               name="smartCardUser"
+               readonly
+               [xc-form-field-tab-index]="data.usernameTabIndex"
+               [xc-form-field-tab-index-suffix]="data.usernameSuffixTabIndex"
+/>
+
+@if (data.roleSelectionDataWrapper && (data.availableRoles || []).length > 0) {
+ <xc-form-autocomplete xc-i18n
+                       label="role-input"
+                       [(xc-form-autocomplete-option)]="data.roleSelectionDataWrapper.value"
+                       [xc-form-autocomplete-options]="data.roleSelectionDataWrapper.values"
+                       [readonly]="data.disabled || (data.availableRoles || []).length <= 1"
+                       xc-form-autocomplete-asdropdown
+                       [xc-form-field-tab-index]="data.roleTabIndex"
+                       [xc-form-field-tab-index-suffix]="data.roleSuffixTabIndex"
  />
+}
+

--- a/auth/forms/smart-card-login.component.ts
+++ b/auth/forms/smart-card-login.component.ts
@@ -19,6 +19,7 @@ import { Component, Input } from '@angular/core';
 
 import { LoginComponentData } from '../login/auth-login.component';
 import { XcFormInputComponent } from '../../xc/xc-form/xc-form-input/xc-form-input.component';
+import { XcFormAutocompleteComponent } from '../../xc/xc-form/xc-form-autocomplete/xc-form-autocomplete.component';
 import { XcI18nTranslateDirective } from '../../i18n/i18n.directive';
 
 
@@ -26,7 +27,7 @@ import { XcI18nTranslateDirective } from '../../i18n/i18n.directive';
     selector: 'smart-card-login',
     templateUrl: './smart-card-login.component.html',
     styleUrls: ['./smart-card-login.component.scss'],
-    imports: [XcFormInputComponent, XcI18nTranslateDirective]
+    imports: [XcFormInputComponent, XcFormAutocompleteComponent, XcI18nTranslateDirective]
 })
 export class SmartCardLoginComponent {
 

--- a/auth/locale/auth-translations.de-DE.ts
+++ b/auth/locale/auth-translations.de-DE.ts
@@ -97,6 +97,10 @@ export const authTranslations_deDE: I18nTranslation[] = [
         key: 'zeta.auth-login.user-input',
         value: 'Benutzer'
     },
+    {
+        key: 'zeta.auth-login.role-input',
+        value: 'Rolle'
+    },
 
     // change-password-dialog
     { key: 'dialog.changePassword.title', value: 'Kennwort ändern' },

--- a/auth/locale/auth-translations.en-US.ts
+++ b/auth/locale/auth-translations.en-US.ts
@@ -96,6 +96,10 @@ export const authTranslations_enUS: I18nTranslation[] = [
         key: 'zeta.auth-login.user-input',
         value: 'User'
     },
+    {
+        key: 'zeta.auth-login.role-input',
+        value: 'Role'
+    },
 
     // change-password-dialog
     { key: 'dialog.changePassword.title', value: 'Change Password' },

--- a/auth/login/auth-login.component.ts
+++ b/auth/login/auth-login.component.ts
@@ -24,6 +24,8 @@ import { environment } from '@environments/environment';
 import { XcI18nContextDirective, XcI18nTranslateDirective } from '../../i18n/i18n.directive';
 import { I18nParam, I18nService } from '../../i18n/i18n.service';
 import { XcDialogService, XcTabBarItem } from '../../xc';
+import { XcAutocompleteDataWrapper } from '../../xc/xc-form/xc-form-autocomplete/xc-form-autocomplete.component';
+import { XcOptionItemString } from '../../xc/shared/xc-item';
 import { XcButtonComponent } from '../../xc/xc-button/xc-button.component';
 import { XcIconComponent } from '../../xc/xc-icon/xc-icon.component';
 import { XcLanguageSelectorComponent } from '../../xc/xc-language-selector/xc-language-selector.component';
@@ -42,10 +44,15 @@ import { WorkflowLoginComponent } from '../forms/workflow-login.component';
 export interface LoginComponentData {
     username: string;
     password?: string;
+    selectedRole?: string;
+    availableRoles?: string[];
+    roleSelectionDataWrapper?: XcAutocompleteDataWrapper<string>;
     disabled?: boolean;
     onEnter: () => void;
     usernameTabIndex: number;
     usernameSuffixTabIndex: number;
+    roleTabIndex?: number;
+    roleSuffixTabIndex?: number;
     passwordTabIndex?: number;
     passwordSuffixTabIndex?: number;
 }
@@ -71,15 +78,25 @@ export class AuthLoginComponent {
     protected readonly i18n = inject(I18nService);
 
 
+    private readonly smartCardRoleDataWrapper = new XcAutocompleteDataWrapper<string>(
+        () => this.smartCardTabItem.data.selectedRole,
+        (role: string) => this.smartCardTabItem.data.selectedRole = role
+    );
+
     readonly smartCardTabItem: LoginTabItem = {
         closable: false,
         component: SmartCardLoginTabComponent,
         name: 'SmartCard',
         data: <LoginComponentData>{
             username: '',
+            selectedRole: undefined,
+            availableRoles: [],
+            roleSelectionDataWrapper: this.smartCardRoleDataWrapper,
             onEnter: this.login.bind(this),
             usernameTabIndex: 1,
             usernameSuffixTabIndex: 4,
+            roleTabIndex: 2,
+            roleSuffixTabIndex: 5,
         }
     };
 
@@ -215,6 +232,14 @@ export class AuthLoginComponent {
         ).subscribe(info => {
             this.smartCardTabItem.data.username = info.username || '';
             this.smartCardDomain = (info.externaldomains || [])[0] || '';
+            const availableRoles = (info.availableRoles || []).filter(role => !!role);
+            this.smartCardTabItem.data.availableRoles = availableRoles;
+            if (availableRoles.length === 0) {
+                this.smartCardTabItem.data.selectedRole = undefined;
+            } else if (!this.smartCardTabItem.data.selectedRole || !availableRoles.includes(this.smartCardTabItem.data.selectedRole)) {
+                this.smartCardTabItem.data.selectedRole = availableRoles[0];
+            }
+            this.smartCardRoleDataWrapper.values = availableRoles.map(role => XcOptionItemString(role));
         });
     }
 
@@ -231,7 +256,7 @@ export class AuthLoginComponent {
     smartCardLogin(force = false) {
         this.pending = true;
         const forcedLogin = force || !!(environment.zeta.auth && environment.zeta.auth.useTheForcedLogin);
-        this.authService.smartCardLogin(this.smartCardDomain, forcedLogin).pipe(
+        this.authService.smartCardLogin(this.smartCardDomain, forcedLogin, this.smartCardTabItem.data.selectedRole).pipe(
             catchError(error => {
                 /**
                  * TODO

--- a/auth/login/auth-login.component.ts
+++ b/auth/login/auth-login.component.ts
@@ -45,7 +45,6 @@ export interface LoginComponentData {
     username: string;
     password?: string;
     selectedRole?: string;
-    availableRoles?: string[];
     roleSelectionDataWrapper?: XcAutocompleteDataWrapper<string>;
     disabled?: boolean;
     onEnter: () => void;
@@ -90,7 +89,6 @@ export class AuthLoginComponent {
         data: <LoginComponentData>{
             username: '',
             selectedRole: undefined,
-            availableRoles: [],
             roleSelectionDataWrapper: this.smartCardRoleDataWrapper,
             onEnter: this.login.bind(this),
             usernameTabIndex: 1,
@@ -231,15 +229,24 @@ export class AuthLoginComponent {
             filter(info => !!info)
         ).subscribe(info => {
             this.smartCardTabItem.data.username = info.username || '';
-            this.smartCardDomain = (info.externaldomains || [])[0] || '';
-            const availableRoles = (info.availableRoles || []).filter(role => !!role);
-            this.smartCardTabItem.data.availableRoles = availableRoles;
-            if (availableRoles.length === 0) {
+            const externalDomains = (info.externaldomains || []).filter(domain => !!domain);
+            const domainNames = externalDomains.length > 0
+                ? externalDomains
+                : (info.domains || []).map(domain => domain.name).filter(name => !!name);
+
+            this.smartCardDomain = domainNames[0] || '';
+
+            const domainFromResponse = (info.domains || []).find(domain => domain.name === this.smartCardDomain)
+                || (info.domains || [])[0];
+
+            const roles = (domainFromResponse?.roles || []).filter(role => !!role);
+
+            if (roles.length === 0) {
                 this.smartCardTabItem.data.selectedRole = undefined;
-            } else if (!this.smartCardTabItem.data.selectedRole || !availableRoles.includes(this.smartCardTabItem.data.selectedRole)) {
-                this.smartCardTabItem.data.selectedRole = availableRoles[0];
+            } else if (!this.smartCardTabItem.data.selectedRole || !roles.includes(this.smartCardTabItem.data.selectedRole)) {
+                this.smartCardTabItem.data.selectedRole = roles[0];
             }
-            this.smartCardRoleDataWrapper.values = availableRoles.map(role => XcOptionItemString(role));
+            this.smartCardRoleDataWrapper.values = roles.map(role => XcOptionItemString(role));
         });
     }
 

--- a/auth/xo/external-user-login-request.model.ts
+++ b/auth/xo/external-user-login-request.model.ts
@@ -32,12 +32,16 @@ export class XoExternalUserLoginRequest extends XoObject {
     @XoProperty()
     path: string;
 
+    @XoProperty()
+    selectedRole: string;
 
-    static withDomain(domain: string, force = false): XoExternalUserLoginRequest {
+
+    static withDomain(domain: string, force = false, selectedRole?: string): XoExternalUserLoginRequest {
         const request = new XoExternalUserLoginRequest();
         request.domain = domain;
         request.force = force;
         request.path = environment.zeta.auth ? environment.zeta.auth.pathToken : '/';
+        request.selectedRole = selectedRole;
         return request;
     }
 }


### PR DESCRIPTION
Adds optional (if one or more roles in the response) dropdown UI for selecting smart card login domain and corresponding role before authentication.

Changes:
New role selection dropdown in smart card tab
role selection based on first domain - preferredDomain from backend