### PR TITLE
Backward compatible dropdown in xc-tree

### DIFF
--- a/xc/xc-tree/xc-structure-tree-data-source.ts
+++ b/xc/xc-tree/xc-structure-tree-data-source.ts
@@ -58,6 +58,12 @@ export class XcStructureTreeDataSource extends XcBaseStructureTreeDataSource {
      */
     complexTypesReadonly = false;
 
+    /**
+     * When true, boolean primitives are rendered as a dropdown instead of
+     * checkbox + autocomplete overlay. Default false preserves legacy behavior.
+     */
+    booleanAsDropdown = false;
+
     private readonly _contentChangeSubject = new Subject<void>();
 
 
@@ -100,13 +106,19 @@ export class XcStructureTreeDataSource extends XcBaseStructureTreeDataSource {
 
 
     protected getPrimitiveTemplates(field: XoStructurePrimitive, _: XcTreeNode): XcTemplate[] {
-        const templates = XcTemplateFactory.createTemplates(
+        let templates = XcTemplateFactory.createTemplates(
             field,
             this.container,
             this.readonlyMode,
             // mark for a change, which eventually updates the autocomplete component
             () => this.triggerMarkForChange()
         );
+        if (this.booleanAsDropdown && field.typeFqn.boolLike && !this.readonlyMode) {
+            templates = templates.filter(template => !(template instanceof XcCheckboxTemplate));
+            templates
+                .filter(template => template instanceof XcFormAutocompleteTemplate)
+                .forEach(template => (template as XcFormAutocompleteTemplate).asDropdown = true);
+        }
         templates.filter(template => template instanceof XcFormTemplate).forEach(template => {
             template.floatLabel = FloatStyle.always;
 

--- a/xc/xc-tree/xc-tree.component.ts
+++ b/xc/xc-tree/xc-tree.component.ts
@@ -30,6 +30,7 @@ import { XcTemplateComponent } from '../xc-template/xc-template.component';
 import { XcTooltipDirective } from '../xc-tooltip/xc-tooltip.directive';
 import { xcTreeTranslations_deDE } from './locale/xc-translations.de-DE';
 import { xcTreeTranslations_enUS } from './locale/xc-translations.en-US';
+import { XcStructureTreeDataSource } from './xc-structure-tree-data-source';
 import { XcTreeDataSource, XcTreeNode } from './xc-tree-data-source';
 
 
@@ -88,6 +89,7 @@ export class XcTreeComponent implements OnDestroy {
 
     private _allowSelect = false;
     private _multiSelect = false;
+    private _booleanAsDropdown = false;
     private _controlPressed = false;
     private _dataSource: XcTreeDataSource<XcTreeNode>;
     private _dataSourceSubscriptions = new Array<Subscription>();
@@ -185,6 +187,22 @@ export class XcTreeComponent implements OnDestroy {
     }
 
 
+    /**
+     * When true, boolean primitives in structure trees are rendered as a dropdown
+     * instead of checkbox + autocomplete overlay. Default false preserves legacy behavior.
+     */
+    @Input('xc-tree-boolean-as-dropdown')
+    set booleanAsDropdown(value: boolean) {
+        this._booleanAsDropdown = coerceBoolean(value);
+        this.applyBooleanAsDropdownToDataSource();
+    }
+
+
+    get booleanAsDropdown(): boolean {
+        return this._booleanAsDropdown;
+    }
+
+
     @Input('xc-tree-datasource')
     set dataSource(value: XcTreeDataSource<any>) {
         this.unsubscribeDataSource();
@@ -216,12 +234,23 @@ export class XcTreeComponent implements OnDestroy {
                     })
                 )
             );
+            this.applyBooleanAsDropdownToDataSource();
         }
     }
 
 
     get dataSource(): XcTreeDataSource<any> {
         return this._dataSource;
+    }
+
+
+    private applyBooleanAsDropdownToDataSource() {
+        if (this._dataSource instanceof XcStructureTreeDataSource) {
+            if (this._dataSource.booleanAsDropdown !== this._booleanAsDropdown) {
+                this._dataSource.booleanAsDropdown = this._booleanAsDropdown;
+                this._dataSource.refresh();
+            }
+        }
     }
 
 


### PR DESCRIPTION
Problem
Boolean fields in structure trees were edited with a checkbox. Users did not expect clicking the checkbox to change the field’s value between false and true, because checkbox labels typically do not change after interaction. A clear value change via a selection control was preferred.

Cause
For boolean primitives, the structure tree rendered a checkbox (optionally with an autocomplete overlay). That control pattern does not communicate a discrete true/false choice as clearly as a dropdown or toggle, so the interaction felt unexpected.

Changes
Added an opt-in mode so boolean primitives can be rendered as a dropdown instead of a checkbox.
XcStructureTreeDataSource: new booleanAsDropdown flag (default false). When enabled and the field is editable, checkbox templates are removed and the boolean autocomplete is forced to dropdown mode.
XcTreeComponent: new input xc-tree-boolean-as-dropdown; applies the flag to a structure-tree data source and refreshes when it changes.
Default remains legacy checkbox behavior so existing consumers are unchanged unless they opt in.

Expected behavior
When xc-tree-boolean-as-dropdown is enabled, editable boolean fields in the structure tree show a true/false dropdown instead of a checkbox. With the flag off (default), behavior is unchanged. Consumers that do not set the input continue to work without API changes.